### PR TITLE
Annotator update

### DIFF
--- a/client/src/Annotator/Annotator.tsx
+++ b/client/src/Annotator/Annotator.tsx
@@ -28,9 +28,11 @@ const Annotator: React.FC<{ imageId: number }> = ({ imageId }) => {
         selected,
         setSelected,
     } = useChoices();
-    const dataset = useDataset(imageId);
-    const info = useInfo(dataset.categories);
-    const filter = useFilter(dataset.categories);
+    const { categories, filename, previous, next, isLoading } = useDataset(
+        imageId,
+    );
+    const info = useInfo(categories);
+    const filter = useFilter(categories);
     const cursor = useCursor(activeTool, selected.annotationId);
 
     // all Paper.js data & callbacks
@@ -42,7 +44,7 @@ const Annotator: React.FC<{ imageId: number }> = ({ imageId }) => {
         onWheelAction,
     } = useCanvas(`/api/image/${imageId}`);
 
-    const groups = useGroups(dataset.categories, selected);
+    const groups = useGroups(categories, selected);
     const tools = useTools(
         paperRef,
         activeTool,
@@ -58,7 +60,7 @@ const Annotator: React.FC<{ imageId: number }> = ({ imageId }) => {
         groups.keypoints.add,
     );
 
-    useTitle(imageInfo.size, dataset.filename);
+    useTitle(imageInfo.size, filename);
 
     return (
         <div className={classes.root}>
@@ -97,9 +99,9 @@ const Annotator: React.FC<{ imageId: number }> = ({ imageId }) => {
             <Box className={classes.rightPanel}>
                 <Panel.FileTile
                     className={classes.fileTitle}
-                    filename={dataset.filename}
-                    prevImgId={dataset.previous}
-                    nextImgId={dataset.next}
+                    filename={filename}
+                    prevImgId={previous}
+                    nextImgId={next}
                     changeImage={id => {
                         navigate(`/annotate/${id}`);
                     }}
@@ -192,13 +194,11 @@ const Annotator: React.FC<{ imageId: number }> = ({ imageId }) => {
                 {info.data.length === 0 && (
                     <Box textAlign="center">
                         <CircularProgress />
-                        {!dataset.isLoading &&
-                            dataset.categories.length === 0 && (
-                                <div>
-                                    No categories have been enabled for this
-                                    image
-                                </div>
-                            )}
+                        {!isLoading && categories.length === 0 && (
+                            <div>
+                                No categories have been enabled for this image
+                            </div>
+                        )}
                     </Box>
                 )}
 

--- a/client/src/Annotator/Info/useChoices.tsx
+++ b/client/src/Annotator/Info/useChoices.tsx
@@ -16,7 +16,7 @@ interface UseChoicesResponse {
     segmentMode: [boolean, Dispatch<SetStateAction<boolean>>];
     toolState: [Maybe<Tool>, (name: Tool) => void];
     selected: SelectedState;
-    setSelected: (catId: number, annotationId?: number) => void;
+    setSelected: (catId: Maybe<number>, annotationId: Maybe<number>) => void;
 }
 
 const useChoices: IUseChoices = () => {
@@ -31,12 +31,15 @@ const useChoices: IUseChoices = () => {
         _setTool(oldState => (oldState === name ? null : name));
     }, []);
 
-    const setSelected = useCallback((catId: number, annotationId?: number) => {
-        _setSelected({
-            categoryId: catId,
-            annotationId: annotationId || null,
-        });
-    }, []);
+    const setSelected = useCallback(
+        (catId: Maybe<number>, annotationId: Maybe<number>) => {
+            _setSelected({
+                categoryId: catId,
+                annotationId: annotationId || null,
+            });
+        },
+        [],
+    );
 
     return {
         segmentMode,

--- a/client/src/Annotator/Info/useDataset.tsx
+++ b/client/src/Annotator/Info/useDataset.tsx
@@ -10,23 +10,36 @@ import * as AnnotatorApi from '../annotator.api';
 import useGlobalContext from '../../common/hooks/useGlobalContext';
 import { addProcess, removeProcess } from '../../common/utils/globalActions';
 
-const useDataset = (imageId: number) => {
+interface IUseDataset {
+    (imageId: number): IUseDatasetResponse;
+}
+interface IUseDatasetResponse {
+    dataset: Maybe<Dataset>;
+    categories: Category[];
+    filename: string;
+    next: Maybe<number>;
+    previous: Maybe<number>;
+    isLoading: boolean;
+}
+
+const useDataset: IUseDataset = imageId => {
     const [, dispatch] = useGlobalContext();
 
     // datasetdata
     const [dataset, setDataset] = useState<Maybe<Dataset>>(null);
     const [categories, setCategories] = useState<Array<Category>>([]);
+    const [isLoading, _setIsLoading] = useState<boolean>(false);
 
     // image data
-    const [metadata, setMetadata] = useState<Maybe<{}>>(null);
+    const [, setMetadata] = useState<Maybe<{}>>(null);
     const [filename, setFilename] = useState<string>('');
     const [next, setNext] = useState<Maybe<number>>(null);
     const [previous, setPrevious] = useState<Maybe<number>>(null);
-    const [categoriesIds, setCategoriesIds] = useState<Array<number>>([]);
-    const [annotating, setAnnotating] = useState<[]>([]);
+    const [, setCategoriesIds] = useState<Array<number>>([]);
+    const [, setAnnotating] = useState<[]>([]);
 
     // others
-    const [preferences, setPreferences] = useState<{}>({}); // TODO adjust type
+    const [, setPreferences] = useState<{}>({}); // TODO adjust type
 
     useEffect(() => {
         const process = 'Loading annotation data';
@@ -48,11 +61,13 @@ const useDataset = (imageId: number) => {
         };
 
         try {
+            _setIsLoading(true);
             addProcess(dispatch, process);
             update();
         } catch (error) {
             // TODO display toast
         } finally {
+            _setIsLoading(false);
             removeProcess(dispatch, process);
         }
     }, [imageId, dispatch]);
@@ -60,13 +75,10 @@ const useDataset = (imageId: number) => {
     return {
         dataset,
         categories,
-        metadata,
         filename,
         next,
         previous,
-        categoriesIds,
-        annotating,
-        preferences,
+        isLoading,
     };
 };
 export default useDataset;

--- a/client/src/Annotator/Info/useDataset.tsx
+++ b/client/src/Annotator/Info/useDataset.tsx
@@ -31,12 +31,14 @@ const useDataset: IUseDataset = imageId => {
     const [isLoading, _setIsLoading] = useState<boolean>(false);
 
     // image data
-    const [, setMetadata] = useState<Maybe<{}>>(null);
+    const [, setMetadata] = useState<{
+        [key: string]: string | number;
+    }>({});
     const [filename, setFilename] = useState<string>('');
     const [next, setNext] = useState<Maybe<number>>(null);
     const [previous, setPrevious] = useState<Maybe<number>>(null);
     const [, setCategoriesIds] = useState<Array<number>>([]);
-    const [, setAnnotating] = useState<[]>([]);
+    const [, setAnnotating] = useState<string[]>([]); // array of users names, which touched specific image
 
     // others
     const [, setPreferences] = useState<{}>({}); // TODO adjust type

--- a/client/src/Annotator/Info/useFilter.tsx
+++ b/client/src/Annotator/Info/useFilter.tsx
@@ -7,21 +7,33 @@ interface IUseFilter {
 }
 interface UseFilterResponse {
     searchText: string;
-    filteredIds: number[];
+    filterObj: FilterObj;
     setSearchText: (val: string) => void;
+}
+
+interface FilterObj {
+    [key: number]: boolean;
 }
 
 const useFilter: IUseFilter = categories => {
     const [searchText, _setSearchText] = useState<string>('');
 
-    const filteredIds: number[] = useMemo(() => {
-        if (searchText.length <= 2) {
-            return categories.map(o => o.id);
-        }
+    const filterObj: FilterObj = useMemo(() => {
         const search = searchText.toLowerCase();
-        return categories
-            .filter(category => category.name.toLowerCase().includes(search))
-            .map(o => o.id);
+        let ids: number[] = [];
+        if (searchText.length >= 2) {
+            ids = categories
+                .filter(category =>
+                    category.name.toLowerCase().includes(search),
+                )
+                .map(o => o.id);
+        } else {
+            ids = categories.map(o => o.id);
+        }
+        return ids.reduce((prevObj: FilterObj, item: number) => {
+            prevObj[item] = true;
+            return prevObj;
+        }, {});
     }, [categories, searchText]);
 
     const setSearchText = useCallback((value: string) => {
@@ -30,7 +42,7 @@ const useFilter: IUseFilter = categories => {
 
     return {
         searchText,
-        filteredIds,
+        filterObj,
         setSearchText,
     };
 };

--- a/client/src/Annotator/Menu/ToolButton.tsx
+++ b/client/src/Annotator/Menu/ToolButton.tsx
@@ -20,7 +20,7 @@ const ToolButton: React.FC<Props> = ({
     <Tooltip
         title={
             enabled
-                ? `${name} tool`
+                ? `${name}`
                 : `${name} (select an annotation to activate tool)`
         }
         placement="right"

--- a/client/src/Annotator/Panel/Category/AnnotationCard.tsx
+++ b/client/src/Annotator/Panel/Category/AnnotationCard.tsx
@@ -52,8 +52,11 @@ const AnnotationCard: React.FC<Props> = ({
                 </IconButton>
             </Grid>
             <Grid item xs={7}>
-                <Typography align="center" onClick={setSelected}>
-                    {`${name != null ? name : '-'} (${true ? 'Empty' : id})`}
+                <Typography align="left" onClick={setSelected}>
+                    <small>
+                        <span>[{id}] </span>
+                        <span>{name || 'No Name'}</span>
+                    </small>
                 </Typography>
             </Grid>
             <Grid item xs>

--- a/client/src/Annotator/Panel/Category/CategoryCard.tsx
+++ b/client/src/Annotator/Panel/Category/CategoryCard.tsx
@@ -20,6 +20,7 @@ interface Props {
     isSelected: boolean;
     isEnabled: boolean;
     isExpanded: boolean;
+    annotationCount: number;
 
     setSelected: (id: number) => void;
     setEnabled: (id: number) => void;
@@ -31,11 +32,12 @@ interface Props {
 }
 
 const CategoryCard: React.FC<Props> = ({
-    data: { id, name, annotations, color },
+    data: { id, name, color },
     isVisible,
     isSelected,
     isEnabled,
     isExpanded,
+    annotationCount,
 
     setSelected,
     setEnabled,
@@ -72,7 +74,6 @@ const CategoryCard: React.FC<Props> = ({
                 </Grid>
                 <Grid item xs={7}>
                     <Typography
-                        align="center"
                         onClick={() => {
                             if (!isSelected) {
                                 setSelected(id);
@@ -80,7 +81,7 @@ const CategoryCard: React.FC<Props> = ({
                             setExpanded(id);
                         }}
                     >
-                        {`${name} (${annotations && annotations.length})`}
+                        {`${name} (${annotationCount})`}
                     </Typography>
                 </Grid>
                 <Grid item xs>
@@ -109,7 +110,7 @@ const CategoryCard: React.FC<Props> = ({
 
             <Collapse in={isExpanded}>
                 <Divider />
-                {isExpanded && annotations && renderExpandedList()}
+                {isExpanded && annotationCount > 0 && renderExpandedList()}
             </Collapse>
         </Card>
     );

--- a/client/src/Annotator/Panel/Category/annotationCard.styles.tsx
+++ b/client/src/Annotator/Panel/Category/annotationCard.styles.tsx
@@ -14,6 +14,7 @@ export const useStyles = makeStyles((theme: AugmentedTheme) => ({
     },
     disabledEye: {
         color: 'grey',
+        opacity: 0.5,
     },
     colorEye: {
         color: (props: Props) => props.color,

--- a/client/src/Annotator/Panel/Category/categoryCard.styles.tsx
+++ b/client/src/Annotator/Panel/Category/categoryCard.styles.tsx
@@ -17,6 +17,7 @@ export const useStyles = makeStyles((theme: AugmentedTheme) => ({
     },
     expanededEye: {
         color: theme.palette.common.white,
+        opacity: 0.1,
     },
     disabledEye: {
         color: 'grey',

--- a/client/src/Annotator/Paper/Group/AnnotationGroup.ts
+++ b/client/src/Annotator/Paper/Group/AnnotationGroup.ts
@@ -1,0 +1,66 @@
+import paper from 'paper';
+
+import * as CONFIG from '../../annotator.config';
+
+import * as shapeUtils from '../Utils/shapeUtils';
+
+import AnnotationShape from './AnnotationShape';
+import KeypointsGroup from './KeypointsGroup';
+
+class AnnotationGroup extends paper.Group {
+    public shape: AnnotationShape;
+    public keypoints: KeypointsGroup;
+
+    constructor(categoryId: number, annotationId: number) {
+        super();
+        this.name = CONFIG.ANNOTATION_GROUP_PREFIX + annotationId;
+        this.data = { categoryId, annotationId };
+
+        this.shape = shapeUtils.create(categoryId, annotationId);
+
+        this.keypoints = new KeypointsGroup();
+        this.keypoints.name = CONFIG.ANNOTATION_KEYPOINTS_PREFIX + annotationId;
+
+        this.addChildren([this.shape, this.keypoints]);
+    }
+
+    // shape methods
+    public uniteShape(toAdd: paper.Path) {
+        if (this.shape.isBBOX) this.shape.disableBBOX();
+
+        const newPath = shapeUtils.unite(this.shape, toAdd, false);
+        const isReplaced = this.shape.replaceWith(newPath);
+        if (isReplaced) this.shape = newPath;
+    }
+
+    public subtractShape(toRemove: paper.Path) {
+        if (this.shape.isBBOX) this.shape.disableBBOX();
+
+        const newPath = shapeUtils.subtract(this.shape, toRemove);
+        const isReplaced = this.shape.replaceWith(newPath);
+        if (isReplaced) this.shape = newPath;
+    }
+
+    public simplifyShape() {
+        if (this.shape.isBBOX) this.shape.disableBBOX();
+
+        shapeUtils.simplify(this.shape);
+    }
+
+    public uniteBBOX(toAdd: paper.Path) {
+        if (!this.shape.isBBOX) {
+            this.shape.activateBBOX();
+
+            const newPath = shapeUtils.unite(this.shape, toAdd, true);
+            const isReplaced = this.shape.replaceWith(newPath);
+            if (isReplaced) this.shape = newPath;
+        } else {
+            console.log('Info: Cannot add new BBOX to existing one');
+        }
+    }
+
+    public exportData() {
+        return ''; // TODO
+    }
+}
+export default AnnotationGroup;

--- a/client/src/Annotator/Paper/Group/AnnotationShape.ts
+++ b/client/src/Annotator/Paper/Group/AnnotationShape.ts
@@ -1,0 +1,30 @@
+import paper from 'paper';
+
+class AnnotationShape extends paper.CompoundPath {
+    private _isBBOX: boolean;
+
+    constructor(object: object, isBBOX?: boolean) {
+        super(object); // object might contain segments & curves from copied path
+        this._isBBOX = isBBOX || false;
+    }
+
+    get isBBOX() {
+        return this._isBBOX;
+    }
+
+    public activateBBOX() {
+        console.log('Info: BBOX Create - All children will be removed');
+        this._isBBOX = true;
+        this.removeChildren();
+    }
+
+    public disableBBOX() {
+        console.log('Info: BBOX Edit - BBOX properties will be lost!');
+        this._isBBOX = false;
+    }
+
+    public exportData() {
+        return ''; // TODO
+    }
+}
+export default AnnotationShape;

--- a/client/src/Annotator/Paper/Group/CategoryGroup.tsx
+++ b/client/src/Annotator/Paper/Group/CategoryGroup.tsx
@@ -1,0 +1,16 @@
+import paper from 'paper';
+
+import * as CONFIG from '../../annotator.config';
+
+class CategoryGroup extends paper.Group {
+    constructor(categoryId: number) {
+        super();
+        this.name = CONFIG.CATEGORY_GROUP_PREFIX + categoryId;
+        this.data = { categoryId };
+    }
+
+    public exportData() {
+        return ''; // TODO
+    }
+}
+export default CategoryGroup;

--- a/client/src/Annotator/Paper/Group/Keypoint.ts
+++ b/client/src/Annotator/Paper/Group/Keypoint.ts
@@ -1,0 +1,38 @@
+import paper from 'paper';
+
+class Keypoint extends paper.Path {
+    public pointId: number; // id is reserverd for paper.Path object
+    private _point: paper.Point;
+
+    constructor(id: number, point: paper.Point) {
+        super();
+        this.pointId = id;
+        this._point = point;
+        this.remove();
+
+        // Copy segments from Path.Circle into new paper.Path
+        // Keypoint has to inherit from paper.Path
+        // because is no such class as paper.Path.Circle... only constructor :-(
+        const circle = new paper.Path.Circle(point, 5);
+        circle.remove();
+        this.addSegments(circle.segments);
+        this.closed = true;
+
+        this.fillColor = new paper.Color('red');
+    }
+
+    move(point: paper.Point) {
+        this._point = point;
+        this.position = point;
+    }
+
+    get point() {
+        return this._point;
+    }
+
+    set selected(val: boolean) {
+        this.strokeColor = new paper.Color(val ? 'white' : 'red');
+        this.bringToFront();
+    }
+}
+export default Keypoint;

--- a/client/src/Annotator/Paper/Group/KeypointsGroup.ts
+++ b/client/src/Annotator/Paper/Group/KeypointsGroup.ts
@@ -1,0 +1,229 @@
+import paper from 'paper';
+
+import { DataType, DataIndicator } from '../../annotator.types';
+
+import Keypoint from './Keypoint';
+
+type Edge = [number, number]; // edge between two keypoints
+
+interface KeypointData {
+    pointId: number;
+    x: number;
+    y: number;
+}
+
+class KeypointsGroup extends paper.Group {
+    private _usedIds: number[]; // array of used ids ( sorted ) - ids start from 1
+    private _keypoints: Keypoint[];
+
+    private _edges: Edge[]; // [ [1,2], [1,3] ] - represent pairs of connected keypoints [id1, id2] - first elem is always smaller
+    private _keypointsEdges: { [pointId: number]: number[] }; // keypoint.pointId -> edgeHash[]
+    private _lines: { [hash: number]: paper.Path.Line }; // edgeHash -> paper.Path.Line
+
+    private _strokeColor: paper.Color;
+    private _lineWidth: number;
+
+    constructor() {
+        super();
+        this._usedIds = [];
+        this._keypoints = [];
+
+        this._edges = [];
+        this._keypointsEdges = {};
+
+        this._lines = {};
+
+        this._strokeColor = new paper.Color('red');
+        this._lineWidth = 4;
+    }
+
+    // public
+    public addKeypoint(point: paper.Point, id?: number) {
+        const newId = this._getNextId(id);
+
+        const keypoint: Keypoint = new Keypoint(newId, point);
+
+        this._keypoints.push(keypoint);
+
+        this.addChild(keypoint);
+        keypoint.bringToFront();
+    }
+
+    public removeKeypoint(keypoint: Keypoint) {
+        // remove all connected lines to keypoint
+        this._removeEdge(keypoint);
+
+        // remove keypoint from group
+        const idx = this._keypoints.findIndex(o => o === keypoint);
+        if (idx > -1) this._keypoints.splice(idx, 1);
+        keypoint.remove();
+    }
+
+    public moveKeypoint(keypoint: Keypoint, point: paper.Point) {
+        const id = keypoint.pointId;
+
+        // move all connected lines accordingly
+        const hashes = this._keypointsEdges[id];
+        if (hashes) {
+            hashes.forEach(edgeHash => {
+                const line = this._lines[edgeHash];
+                if (line) {
+                    for (let i = 0; i < line.segments.length; i++) {
+                        const segment = line.segments[i];
+                        if (segment.point.isClose(keypoint.point, 0)) {
+                            segment.point = point;
+                            break;
+                        }
+                    }
+                }
+            });
+        }
+        keypoint.move(point);
+        keypoint.bringToFront();
+    }
+
+    public linkKeypoints(k1: Keypoint, k2: Keypoint) {
+        const pointId1 = k1.pointId;
+        const pointId2 = k2.pointId;
+
+        const edge: Edge =
+            pointId1 < pointId2 ? [pointId1, pointId2] : [pointId2, pointId1];
+        const edgeHash = this._hashEdge(edge);
+
+        // remove line between two keypoints
+        if (this._lines[edgeHash]) {
+            this._removeEdge(k1, edgeHash);
+            this._removeEdge(k2, edgeHash);
+        }
+        // connect two keypoint with line
+        else {
+            this._addEdge(edge, k1, k2);
+        }
+    }
+
+    public importData(keypoints: KeypointData[], edges: Edge[]) {
+        this._usedIds = keypoints.map(k => k.pointId).sort();
+
+        // add keypoints
+        keypoints.forEach(k => {
+            this.addKeypoint(new paper.Point(k.x, k.y), k.pointId);
+        });
+
+        // link keypoints with lines
+        edges.forEach(edge => {
+            const [id1, id2] = edge;
+
+            const k1 = this._keypoints.find(o => o.pointId === id1);
+            const k2 = this._keypoints.find(o => o.pointId === id2);
+
+            if (k1 && k2) {
+                this._addEdge(edge, k1, k2);
+            }
+        });
+    }
+
+    public exportData() {
+        const keypoints: KeypointData[] = this._keypoints.map(k => ({
+            pointId: k.pointId,
+            x: k.point.x,
+            y: k.point.y,
+        }));
+        const edges = this._edges;
+
+        return {
+            keypoints,
+            edges,
+        };
+    }
+
+    // private
+    private _addEdge(edge: Edge, k1: Keypoint, k2: Keypoint) {
+        const edgeHash = this._hashEdge(edge);
+
+        this._edges.push(edge);
+
+        if (!this._keypointsEdges[k1.pointId])
+            this._keypointsEdges[k1.pointId] = [];
+        if (!this._keypointsEdges[k2.pointId])
+            this._keypointsEdges[k2.pointId] = [];
+
+        this._keypointsEdges[k1.pointId].push(edgeHash);
+        this._keypointsEdges[k2.pointId].push(edgeHash);
+
+        const line = this._createLine(k1.point, k2.point);
+        this._lines[edgeHash] = line;
+        line.insertAbove(k2);
+    }
+
+    private _removeEdge(keypoint: Keypoint, edgeHashToRemove?: number) {
+        const pointId = keypoint.pointId;
+
+        if (!this._keypointsEdges[pointId]) return;
+
+        const hashes = this._keypointsEdges[pointId];
+
+        // remove only one edge
+        if (edgeHashToRemove != null) {
+            if (this._lines[edgeHashToRemove]) {
+                const line = this._lines[edgeHashToRemove];
+                line.remove();
+                delete this._lines[edgeHashToRemove];
+            }
+            const idx = this._keypointsEdges[pointId].findIndex(
+                o => o === edgeHashToRemove,
+            );
+            this._keypointsEdges[pointId].splice(idx, 1);
+        }
+        // blow up all edges
+        else {
+            hashes.forEach(edgeHash => {
+                if (this._lines[edgeHash]) {
+                    const line = this._lines[edgeHash];
+                    line.remove();
+                    delete this._lines[edgeHash];
+                }
+            });
+            delete this._keypointsEdges[pointId];
+        }
+
+        this._edges = this._edges.filter(
+            edge => edge[0] !== pointId && edge[1] !== pointId,
+        );
+    }
+
+    private _hashEdge(edge: Edge) {
+        // Order doesn't matter so can sort first
+        const min = Math.min(edge[0], edge[1]);
+        const max = Math.max(edge[0], edge[1]);
+        // Cantor pairing function
+        const add = min + max;
+        return (1 / 2) * add * (add - 1) - max;
+    }
+
+    private _createLine(p1: paper.Point, p2: paper.Point) {
+        const data: DataIndicator = { type: DataType.INDICATOR };
+        const line = new paper.Path.Line(p1, p2);
+        line.strokeColor = this._strokeColor;
+        line.strokeWidth = this._lineWidth;
+        line.data = data;
+        line.remove();
+
+        return line;
+    }
+
+    private _getNextId(id?: number) {
+        const count = this._usedIds.length;
+
+        let newId; // ids start from 1
+
+        if (id) newId = id;
+        else if (count === 0) newId = 1;
+        else newId = this._usedIds[count - 1] + 1; // highestId + 1
+
+        this._usedIds.push(newId);
+        this._usedIds.sort();
+
+        return newId;
+    }
+}
+export default KeypointsGroup;

--- a/client/src/Annotator/Paper/Group/index.tsx
+++ b/client/src/Annotator/Paper/Group/index.tsx
@@ -1,0 +1,13 @@
+import CategoryGroup from './CategoryGroup';
+import AnnotationGroup from './AnnotationGroup';
+import AnnotationShape from './AnnotationShape';
+import KeypointsGroup from './KeypointsGroup';
+import Keypoint from './Keypoint';
+
+export {
+    CategoryGroup,
+    AnnotationGroup,
+    AnnotationShape,
+    KeypointsGroup,
+    Keypoint,
+};

--- a/client/src/Annotator/Paper/Tool/useBBox.tsx
+++ b/client/src/Annotator/Paper/Tool/useBBox.tsx
@@ -13,7 +13,7 @@ interface IToolBBox {
     (
         enabled: boolean,
         scale: number,
-        updateAnnotation: (a: paper.Path) => void,
+        uniteBBox: (a: paper.Path) => void,
     ): ToolBBoxResponse;
 }
 export interface ToolBBoxResponse {
@@ -29,7 +29,7 @@ interface PathOptions {
     strokeWidth: number;
 }
 
-export const useBBox: IToolBBox = (isActive, scale, updateAnnotation) => {
+export const useBBox: IToolBBox = (isActive, scale, uniteBBox) => {
     const toolRef = useRef<Maybe<paper.Tool>>(null);
     const polygonRef = useRef<Maybe<paper.Path>>(null);
     const pointRef = useRef<PointCache>({
@@ -88,7 +88,7 @@ export const useBBox: IToolBBox = (isActive, scale, updateAnnotation) => {
         polygonRef.current.fillColor = new paper.Color('black');
         polygonRef.current.closePath();
 
-        updateAnnotation(polygonRef.current); // TODO probably more parameters
+        uniteBBox(polygonRef.current);
 
         polygonRef.current.remove();
         polygonRef.current = null;
@@ -96,9 +96,8 @@ export const useBBox: IToolBBox = (isActive, scale, updateAnnotation) => {
         pointRef.current.p1 = null;
         pointRef.current.p2 = null;
 
-        //removeUndos(this.actionTypes.ADD_POINTS); // TODO implement undo mechanism
         return true;
-    }, [updateAnnotation]);
+    }, [uniteBBox]);
 
     const removeLastBBox = useCallback(() => {
         if (polygonRef.current != null) {
@@ -162,7 +161,7 @@ export const useBBox: IToolBBox = (isActive, scale, updateAnnotation) => {
     }, [isActive]);
 
     useEffect(() => {
-        const newScale = scale * CONFIG.TOOL_SCALE_FACTOR;
+        const newScale = scale * CONFIG.TOOLS_BBOX_SCALE_FACTOR;
 
         optionsRef.current.strokeWidth = newScale;
         if (polygonRef.current != null) {

--- a/client/src/Annotator/Paper/Tool/useBrush.tsx
+++ b/client/src/Annotator/Paper/Tool/useBrush.tsx
@@ -39,10 +39,10 @@ export const useBrush: IToolBrush = (
     const brushRef = useRef<Maybe<paper.Path.Circle>>(null);
     const optionsRef = useRef<PathOptions>({
         strokeColor: 'white',
-        strokeWidth: CONFIG.TOOLS_INITIAL_STROKE_WIDTH,
-        radius: CONFIG.TOOLS_INITIAL_RADIUS,
+        strokeWidth: CONFIG.TOOLS_BRUSH_INITIAL_STROKE_WIDTH,
+        radius: CONFIG.TOOLS_BRUSH_INITIAL_RADIUS,
     });
-    const [radius, _setRadius] = useState(CONFIG.TOOLS_INITIAL_RADIUS);
+    const [radius, _setRadius] = useState(CONFIG.TOOLS_BRUSH_INITIAL_RADIUS);
     const [color, _setColor] = useState('white');
 
     // private actions
@@ -61,10 +61,8 @@ export const useBrush: IToolBrush = (
     const _moveBrush = useCallback(
         (point: paper.Point) => {
             if (brushRef.current == null) {
-                console.log('---create brush');
                 brushRef.current = _createBrush(point);
             }
-            console.log('---move brush');
             brushRef.current.bringToFront();
             brushRef.current.position = point;
         },
@@ -147,7 +145,8 @@ export const useBrush: IToolBrush = (
     useEffect(() => {
         //this.eraser.pathOptions.strokeWidth = newScale * this.scaleFactor;
         if (brushRef.current != null) {
-            brushRef.current.strokeWidth = scale * CONFIG.TOOL_SCALE_FACTOR;
+            brushRef.current.strokeWidth =
+                scale * CONFIG.TOOLS_BRUSH_SCALE_FACTOR;
         }
     }, [scale]);
 

--- a/client/src/Annotator/Paper/Utils/groupUtils.tsx
+++ b/client/src/Annotator/Paper/Utils/groupUtils.tsx
@@ -1,0 +1,34 @@
+import { Maybe } from '../../annotator.types';
+
+import { CategoryGroup, AnnotationGroup } from '../Group';
+
+export const findCategoryGroup = (
+    groups: CategoryGroup[],
+    categoryId: number,
+): Maybe<CategoryGroup> => {
+    const idx = groups.findIndex(o => o.data.categoryId === categoryId);
+
+    if (idx === -1) return null;
+
+    return groups[idx];
+};
+
+export const findAnnotationGroup = (
+    groups: CategoryGroup[],
+    categoryId: Maybe<number>,
+    annotationId: Maybe<number>,
+): Maybe<AnnotationGroup> => {
+    const idx = groups.findIndex(o => o.data.categoryId === categoryId);
+    if (idx === -1) return null;
+
+    const aIdx = groups[idx].children.findIndex(
+        o => o.data.annotationId === annotationId,
+    );
+    if (aIdx === -1) return null;
+
+    const group = groups[idx].children[aIdx];
+
+    if (group instanceof AnnotationGroup) return group;
+
+    return null;
+};

--- a/client/src/Annotator/Paper/Utils/selectUtils.tsx
+++ b/client/src/Annotator/Paper/Utils/selectUtils.tsx
@@ -77,9 +77,9 @@ const createShapeText = (
     annotationId: Maybe<number>,
 ) => {
     // info text
-    let msg;
-    msg = `CategoryId: ${categoryId}\nAnnotationId: ${annotationId}`;
-    msg.replace(/\n/g, ' \n ').slice(0, -2);
+    const msg = `CategoryId: ${categoryId}\nAnnotationId: ${annotationId}`
+        .replace(/\n/g, ' \n ')
+        .slice(0, -2);
 
     // metadataData text
     const metadata: Array<{ key: string; value: string }> = []; // TODO get

--- a/client/src/Annotator/Paper/Utils/selectUtils.tsx
+++ b/client/src/Annotator/Paper/Utils/selectUtils.tsx
@@ -1,0 +1,106 @@
+import { Maybe, DataType, DataIndicator } from '../../annotator.types';
+
+import * as CONFIG from '../../annotator.config';
+
+import { Keypoint } from '../Group';
+import { isIndicator } from './typeGuards';
+
+export const hitOptions = {
+    segments: true,
+    stroke: true,
+    fill: false,
+    tolerance: CONFIG.TOOLS_SELECT_INITIAL_HIT_TOLERANCE,
+    match: (hit: { item: { data: Object } }) => {
+        return !isIndicator(hit.item.data);
+    },
+};
+
+export const hitOptionsFill = {
+    segments: false,
+    stroke: false,
+    fill: true,
+    tolerance: CONFIG.TOOLS_SELECT_INITIAL_HIT_TOLERANCE,
+    match: (hit: { item: { data: Object } }) => {
+        return !isIndicator(hit.item.data);
+    },
+};
+
+export const createCircle = (
+    point: paper.Point,
+    radius: number,
+    strokeWidth: number,
+) => {
+    const data: DataIndicator = { type: DataType.INDICATOR };
+
+    const pt = new paper.Path.Circle(point, radius);
+    pt.strokeColor = new paper.Color('black');
+    pt.strokeWidth = strokeWidth;
+    pt.data = data;
+
+    return pt;
+};
+
+export const createTooltip = (
+    position: paper.Point,
+    rounded: number,
+    fontSize: number,
+    keypoint: Maybe<Keypoint>,
+    categoryId: Maybe<number>,
+    annotationId: Maybe<number>,
+) => {
+    // Create tooltip paper object
+    const data: DataIndicator = { type: DataType.INDICATOR };
+
+    const text = new paper.PointText(position);
+    text.justification = 'left';
+    text.fillColor = new paper.Color('black');
+    text.content = keypoint
+        ? createKeypointText(keypoint)
+        : createShapeText(categoryId, annotationId);
+    text.fontSize = fontSize;
+    text.data = data;
+
+    const box = new paper.Path.Rectangle(
+        text.bounds,
+        new paper.Size(rounded, rounded),
+    );
+    box.fillColor = new paper.Color('white');
+    box.strokeColor = new paper.Color('white');
+    box.opacity = 0.5;
+    box.data = data;
+
+    return { text, box };
+};
+
+const createShapeText = (
+    categoryId: Maybe<number>,
+    annotationId: Maybe<number>,
+) => {
+    // info text
+    let msg;
+    msg = `CategoryId: ${categoryId}\nAnnotationId: ${annotationId}`;
+    msg.replace(/\n/g, ' \n ').slice(0, -2);
+
+    // metadataData text
+    const metadata: Array<{ key: string; value: string }> = []; // TODO get
+    let metaMsg = '';
+    if (metadata && metadata.length > 0) {
+        metaMsg += 'Metadata \n';
+        metadata.forEach(e => {
+            if (e.key.length !== 0) {
+                metaMsg += ' ' + e.key + ' = ' + e.value + ' \n';
+            }
+        });
+    } else metaMsg += 'No Metadata \n';
+
+    metaMsg.replace(/\n/g, ' \n ').slice(0, -2);
+
+    return msg + '\n' + metaMsg;
+};
+
+const createKeypointText = (keypoint: Keypoint) => {
+    const id = keypoint.pointId;
+    const msg = `Keypoint \n Id: ${id}`;
+    msg.replace(/\n/g, ' \n ').slice(0, -2);
+    return msg;
+};

--- a/client/src/Annotator/Paper/Utils/typeGuards.tsx
+++ b/client/src/Annotator/Paper/Utils/typeGuards.tsx
@@ -1,23 +1,19 @@
-import {
-    DataType,
-    DataGroup,
-    DataAnnotation,
-    DataIndicator,
-    DataKeypoint,
-} from '../../annotator.types';
+import { DataIndicator, DataType } from '../../annotator.types';
 
-export function isGroup(obj: Object): obj is DataGroup {
-    return (obj as DataGroup).type === DataType.GROUP;
+import { AnnotationShape, KeypointsGroup, Keypoint } from '../Group';
+
+export function isAnnotationShape(obj: Object): obj is AnnotationShape {
+    return obj instanceof AnnotationShape;
 }
 
-export function isAnnotation(obj: Object): obj is DataAnnotation {
-    return (obj as DataAnnotation).type === DataType.ANNOTATION;
+export function isKeypointGroup(obj: Object): obj is KeypointsGroup {
+    return obj instanceof KeypointsGroup;
+}
+
+export function isKeypoint(obj: Object): obj is Keypoint {
+    return obj instanceof Keypoint;
 }
 
 export function isIndicator(obj: Object): obj is DataIndicator {
     return (obj as DataIndicator).type === DataType.INDICATOR;
-}
-
-export function isKeypoint(obj: Object): obj is DataKeypoint {
-    return (obj as DataKeypoint).type === DataType.KEYPOINT;
 }

--- a/client/src/Annotator/Paper/useCanvas.tsx
+++ b/client/src/Annotator/Paper/useCanvas.tsx
@@ -56,12 +56,18 @@ const useCanvas = (imageUrl: string): CanvasState => {
 
         if (e.altKey) {
             // pan up and down
-            const delta = new paper.Point(0, CONFIG.PAN_FACTOR * e.deltaY);
+            const delta = new paper.Point(
+                0,
+                CONFIG.CANVAS_PAN_FACTOR * e.deltaY,
+            );
             const newCenterP = centerPt.add(delta);
             paperRef.current.view.center = newCenterP;
         } else if (e.shiftKey) {
             // pan left and right
-            const delta = new paper.Point(CONFIG.PAN_FACTOR * e.deltaY, 0);
+            const delta = new paper.Point(
+                CONFIG.CANVAS_PAN_FACTOR * e.deltaY,
+                0,
+            );
             const newCenterP = centerPt.add(delta);
             paperRef.current.view.center = newCenterP;
         } else {
@@ -73,15 +79,18 @@ const useCanvas = (imageUrl: string): CanvasState => {
             const oldZoom = view.zoom || 0;
             const newZoom =
                 e.deltaY < 0
-                    ? oldZoom * CONFIG.ZOOM_FACTOR
-                    : oldZoom / CONFIG.ZOOM_FACTOR;
+                    ? oldZoom * CONFIG.CANVAS_ZOOM_FACTOR
+                    : oldZoom / CONFIG.CANVAS_ZOOM_FACTOR;
             const beta = oldZoom / newZoom;
             const pc = viewPosition.subtract(centerPt);
             const newOffset = viewPosition
                 .subtract(pc.multiply(beta))
                 .subtract(centerPt);
 
-            if (newZoom < CONFIG.ZOOM_MAX && newZoom > CONFIG.ZOOM_MIN) {
+            if (
+                newZoom < CONFIG.CANVAS_ZOOM_MAX &&
+                newZoom > CONFIG.CANVAS_ZOOM_MIN
+            ) {
                 _setImgScale(1 / newZoom);
                 paperRef.current.view.zoom = newZoom;
                 paperRef.current.view.center = view.center.add(newOffset);

--- a/client/src/Annotator/Paper/useTools.tsx
+++ b/client/src/Annotator/Paper/useTools.tsx
@@ -24,7 +24,8 @@ interface IUseTools {
         unite: (toAdd: paper.Path) => void,
         subtract: (toRemove: paper.Path) => void,
         simplify: () => void,
-        addKeypoint: () => void,
+        uniteBBOX: (toAdd: paper.Path) => void,
+        addKeypoint: (point: paper.Point) => void,
     ): {
         empty: null;
         select: ToolSelectResponse;
@@ -49,6 +50,7 @@ const useTools: IUseTools = (
     unite,
     subtract,
     simplify,
+    uniteBBOX,
     addKeypoint,
 ) => {
     const isDisabled: boolean = useMemo(() => {
@@ -63,11 +65,10 @@ const useTools: IUseTools = (
         activeTool === Tool.SELECT && selectedAnnotation != null,
         imageScale,
     );
-
     const bbox = useBBox(
         activeTool === Tool.BBOX && selectedAnnotation != null,
         imageScale,
-        unite,
+        uniteBBOX,
     );
     const polygon = usePolygon(
         activeTool === Tool.POLYGON && selectedAnnotation != null,

--- a/client/src/Annotator/annotator.config.tsx
+++ b/client/src/Annotator/annotator.config.tsx
@@ -1,27 +1,33 @@
 export const DEBUGGING_ON = false;
 
-export const ZOOM_FACTOR = 1.2;
-export const ZOOM_MIN = 0.01;
-export const ZOOM_MAX = 10;
+// Info Config
+export const INITIAL_CATEGORY_ID = null;
+export const INITIAL_ANNOTATION_ID = null;
+export const ANNOTATION_EXPANDED = true;
 
-export const PAN_FACTOR = 0.5;
+// Paper.js Config
+export const CANVAS_ZOOM_FACTOR = 1.2;
+export const CANVAS_ZOOM_MIN = 0.01;
+export const CANVAS_ZOOM_MAX = 10;
+export const CANVAS_PAN_FACTOR = 0.5;
+
+export const CATEGORY_GROUP_PREFIX = 'CATEGORY_GROUP_';
+export const ANNOTATION_GROUP_PREFIX = 'ANNOTATION_GROUP_';
+export const ANNOTATION_SHAPE_PREFIX = 'ANNOTATION_SHAPE_';
+export const ANNOTATION_KEYPOINTS_PREFIX = 'KEYPOINTS_';
+
+export const ANNOTATION_SHAPE_OPACITY = 0.6;
 
 export const TITLE_FONT_SCALE = 0.025;
 export const TITLE_HEIGHT_SCALE = 0.5;
 
-export const ANNOTATION_OPACITY = 0.6;
+export const TOOLS_BBOX_SCALE_FACTOR = 3;
 
-export const INITIAL_CATEGORY_ID = null;
-export const INITIAL_ANNOTATION_ID = null;
+export const TOOLS_BRUSH_SCALE_FACTOR = 3;
+export const TOOLS_BRUSH_INITIAL_STROKE_WIDTH = 1;
+export const TOOLS_BRUSH_INITIAL_RADIUS = 30;
 
-export const CATEGORY_NAME_PREFIX = 'CATEGORY_';
-export const ANNOTATION_NAME_PREFIX = 'ANNOTATION_';
-
-export const TOOL_SCALE_FACTOR = 3;
-export const TOOLS_INITIAL_STROKE_WIDTH = 1;
-export const TOOLS_INITIAL_RADIUS = 30;
-
-export const TOOLS_SELECT_INITIAL_TOOLTIP_ON = false;
+export const TOOLS_SELECT_INITIAL_TOOLTIP_ON = true;
 export const TOOLS_SELECT_INITIAL_HIT_TOLERANCE = 10;
 export const TOOLS_SELECT_SCALE_ROUNDED = 5;
 export const TOOLS_SELECT_SCALE_TEXT_SHIFT = 40;

--- a/client/src/Annotator/annotator.types.tsx
+++ b/client/src/Annotator/annotator.types.tsx
@@ -1,6 +1,9 @@
 import paper from 'paper';
+import { Category, Annotation } from '../common/types';
 
 export type Maybe<T> = T | null | undefined;
+
+// info types
 
 export enum Tool {
     SELECT = 'SELECT',
@@ -22,14 +25,29 @@ export enum Cursor {
     DEFAULT = 'default',
 }
 
-export interface ImageSize {
-    width: number;
-    height: number;
-}
-
 export interface SelectedState {
     categoryId: Maybe<number>;
     annotationId: Maybe<number>;
+}
+
+export interface CategoryInfo {
+    id: number;
+    enabled: boolean;
+    expanded: boolean;
+    data: Category;
+    annotations: AnnotationInfo[];
+}
+
+export interface AnnotationInfo {
+    id: number;
+    enabled: boolean;
+    data: Annotation;
+}
+
+// paper types
+export interface ImageSize {
+    width: number;
+    height: number;
 }
 
 export interface MouseEvent {
@@ -39,32 +57,22 @@ export interface MouseEvent {
         shift?: boolean;
     };
 }
-
 export enum DataType {
-    INDICATOR = 'INDICATOR',
-    GROUP = 'GROUP',
-    ANNOTATION = 'ANNOTATION',
+    ANNOTATION_SHAPE = 'ANNOTATION_SHAPE',
     KEYPOINT = 'KEYPOINT',
+    INDICATOR = 'INDICATOR',
 }
-export type DataGroup = {
-    type: DataType.GROUP;
-    categoryId: number;
-};
-export interface DataAnnotation {
-    type: DataType.ANNOTATION;
+
+export interface DataAnnotationShape {
     categoryId: number;
     annotationId: number;
-    isBBox?: boolean;
 }
+
+export interface DataKeypoint {
+    categoryId: number;
+    annotationId: number;
+}
+
 export interface DataIndicator {
     type: DataType.INDICATOR;
-}
-export interface DataKeypoint {
-    type: DataType.KEYPOINT;
-    indexLabel: number;
-    visibility: boolean;
-    keypoints: {
-        labels: string[];
-    };
-    labels: string[];
 }


### PR DESCRIPTION
1) Paper.js Groups & Compound Path Major Changes:
- Add CategoryGroup class, which represent object with multiple Annotations
- Add AnnotationGroup class, which hold references for Annotation Shape & Annotation KeypointsGroup
- Add AnnotationShape class, which represent Annotation CompoundPath (with possibility to mark it as BBOX)
- Add KeypointsGroup class, which hold Annotation Keypoints and edges ( lines ) between them
- Add Keypoint class, which represent single Keypoint circle

2) BBox Feature:

(a) Adjust AnnotationShape to support BBOX property

(b) AnnotationShape with BBOX property represent rectangle shape and behave differently than normal shape

(c) useSelect Tool
- In case click + drag (on BBOX POINT!)-> we resize WHOLE rectangle rather than move point
- In case click + drag (on BBOX FILL!) -> we move WHOLE rectangle

(d) useBBOX Tool
- add new shape -> old shape is removed and replaced with AnnotationShape with BBOX property
- add new shape (in case AnnotationShape BBOX = true) -> prevent from doing anything

(e) usePolygon/useBrush Tool
- unite/subtract new shape into AnnotationShape with BBOX property -> AnnotationShape lost ALL BBOX behaviors and behave as regular path

3) Keypoint Feature:
(a) useKeypoint Tool can add new Keypoints on Project

(b) useSelect Tool
- on click - select Keypoint in some KeypointGroup
- on click on select Keypoint -> unselect Keypoint
- on click on different Keypoint (when some other Keypoint is selected) -> connect two Keypoints with line  / or remove line if already existed
- on click + drag -> move Keypoint to new position & update existing lines between other Keypoints
- on click on selected Keypoint + shift-> remove Keypoint & all existing lines to it

(c) Change format of Keypoint export type

4) Major cleaning for Tools hooks:
- Move AnnotationGroup plain functions into groupUtils
- Move AnnotationShape plain functions into shapeUtils
- Move SelectTool plain functions into selectUtils

5) Major cleaning for useSelect hook - refactor all vague names and group them based on SELECT / HOVER functionality

6) Minor cleaning for useGroup hook - separate useShape and useKeypoint sub-Hooks for managing specific things

7) Manage Annotation Feature:
- Move CategoryInfo and AnnotationInfo to Annotator.types
- Adjust useInfo hook to create / remove annotations ( split it into subHooks )
- Adjust useFilter hook to return Dictionary instead of array
- Adjust useChoices hook setSelected hook
- Adjust useDataset hook response
- Add some Config initial values